### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Potential fix for [https://github.com/DeMaCS-UNICAL/LoIDE-PWA/security/code-scanning/4](https://github.com/DeMaCS-UNICAL/LoIDE-PWA/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow or to the specific job. Since the job only needs to check out code and push to Docker Hub (which does not require repository write permissions), the minimal required permission is `contents: read`. This can be set at the job level (inside `push_to_registry:`) or at the workflow root (applies to all jobs). The best practice is to add `permissions: contents: read` at the job level, just below the job name, to ensure least privilege for this specific job. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
