### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DeMaCS-UNICAL/LoIDE-PWA/security/code-scanning/5](https://github.com/DeMaCS-UNICAL/LoIDE-PWA/security/code-scanning/5)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a test workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job in this workflow, either location is acceptable, but setting it at the workflow level is more future-proof and clear. The change should be made by adding the following block after the `name:` field and before the `on:` field in `.github/workflows/tests.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
