### PR TITLE
Feature/multiple side panels

### DIFF
--- a/src/components/Appearance.tsx
+++ b/src/components/Appearance.tsx
@@ -1,10 +1,12 @@
 import {
   IonButton,
+  IonCol,
   IonIcon,
   IonItem,
   IonList,
   IonListHeader,
   IonRange,
+  IonRow,
   IonToggle,
 } from "@ionic/react";
 import { moonOutline } from "ionicons/icons";
@@ -61,36 +63,42 @@ const Appearance: React.FC = () => {
             Dark mode
           </IonToggle>
         </IonItem>
-        <IonListHeader>Editor</IonListHeader>
-        <IonItem>
-          <IonRange
-            value={fontSizeEditor}
-            onIonChange={onFontEditorChange}
-            min={15}
-            max={30}
-            pin={true}
-            snaps={true}
-            title="Font size editor range"
-            labelPlacement="start"
-            label="Font size"
-            data-testid="font-size-editor-range"
-          ></IonRange>
-        </IonItem>
-        <IonListHeader>Output</IonListHeader>
-        <IonItem>
-          <IonRange
-            value={fontSizeOutput}
-            onIonChange={onFontOutputChange}
-            min={15}
-            max={30}
-            pin={true}
-            snaps={true}
-            title="Font size output range"
-            labelPlacement="start"
-            label="Font size"
-            data-testid="font-size-output-range"
-          ></IonRange>
-        </IonItem>
+        <IonRow>
+          <IonCol>
+            <IonListHeader>Editor</IonListHeader>
+            <IonItem>
+              <IonRange
+                value={fontSizeEditor}
+                onIonChange={onFontEditorChange}
+                min={15}
+                max={30}
+                pin={true}
+                snaps={true}
+                title="Font size editor range"
+                labelPlacement="start"
+                label="Font size"
+                data-testid="font-size-editor-range"
+              ></IonRange>
+            </IonItem>
+          </IonCol>
+          <IonCol>
+            <IonListHeader>Output</IonListHeader>
+            <IonItem>
+              <IonRange
+                value={fontSizeOutput}
+                onIonChange={onFontOutputChange}
+                min={15}
+                max={30}
+                pin={true}
+                snaps={true}
+                title="Font size output range"
+                labelPlacement="start"
+                label="Font size"
+                data-testid="font-size-output-range"
+              ></IonRange>
+            </IonItem>
+          </IonCol>
+        </IonRow>
       </IonList>
       <IonButton
         className="ion-margin-top"

--- a/src/pages/MainTab.tsx
+++ b/src/pages/MainTab.tsx
@@ -12,12 +12,11 @@ import {
   IonPage,
   IonPopover,
   IonSplitPane,
-  IonTitle,
+  // IonTitle,
   IonToolbar,
 } from "@ionic/react";
 import { alertController, actionSheetController } from "@ionic/core";
 import logo from "../assets/img/logo_LoIDE.svg";
-import RunSettings from "../components/RunSettings";
 import LoideRunNavButton from "../components/LoideRunNavButton";
 import Editor from "../components/Editor";
 import OpenProjectModal from "../modals/OpenProjectModal";
@@ -27,6 +26,8 @@ import {
   folderOpenOutline,
   saveOutline,
   shareOutline,
+  ellipseOutline,
+  checkmarkCircleOutline,
 } from "ionicons/icons";
 import SaveProjectModal from "../modals/SaveProjectModal";
 import { ActionSheet, ButtonText, WindowConfirmMessages } from "../lib/constants";
@@ -37,6 +38,9 @@ import { useSelector } from "react-redux";
 import { languagesDataSelector } from "../redux/slices/LanguagesData";
 import RestoreButton from "../components/RestoreButton";
 import Mousetrap from "mousetrap";
+import { useIsMobile } from "../hooks/useIsMobile";
+import RunSettingsTab from "./RunSettingsTab";
+import OutputTab from "./OutputTab";
 
 type MainTabPageProps = RouteComponentProps<{
   data: string;
@@ -50,6 +54,11 @@ const MainTab: React.FC<MainTabPageProps> = ({ match }) => {
     open: boolean;
     event: Event | undefined;
   }>({ open: false, event: undefined });
+
+  const [pinnedTabs, setPinnedTabs] = useState({
+    settings: !useIsMobile,
+    output: !useIsMobile,
+  });
 
   const { languages } = useSelector(languagesDataSelector);
 
@@ -148,6 +157,26 @@ const MainTab: React.FC<MainTabPageProps> = ({ match }) => {
           <IonButtons slot="start">
             <LoideRunNavButton />
           </IonButtons>
+          <IonButtons slot="start">
+            <IonIcon
+              icon={pinnedTabs.settings ? checkmarkCircleOutline : ellipseOutline}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setPinnedTabs({ ...pinnedTabs, settings: !pinnedTabs.settings });
+              }}
+              style={{ marginLeft: "4px", cursor: "pointer" }}
+            />
+            <IonIcon
+              icon={pinnedTabs.output ? checkmarkCircleOutline : ellipseOutline}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setPinnedTabs({ ...pinnedTabs, output: !pinnedTabs.output });
+              }}
+              style={{ marginLeft: "4px", cursor: "pointer" }}
+            />
+          </IonButtons>
           <img
             className="logo"
             style={{
@@ -215,21 +244,38 @@ const MainTab: React.FC<MainTabPageProps> = ({ match }) => {
       <IonContent scrollY={false} className="tab-content-of-hidden">
         <IonSplitPane contentId="main" when="lg">
           {/*--  the side menu  --*/}
-          <IonMenu contentId="main">
-            <IonHeader>
-              <IonToolbar className="side-toolbar">
-                <IonTitle>Run settings</IonTitle>
-              </IonToolbar>
-            </IonHeader>
-            <IonContent forceOverscroll={true}>
-              <RunSettings />
-            </IonContent>
-          </IonMenu>
+          {pinnedTabs.settings && (
+            <IonMenu contentId="main">
+              {/* <IonHeader>
+                <IonToolbar className="side-toolbar">
+                  <IonTitle>Run settings</IonTitle>
+                </IonToolbar>
+              </IonHeader>
+              <IonContent forceOverscroll={true}>
+                <RunSettings />
+              </IonContent> */}
+              <RunSettingsTab />
+            </IonMenu>
+          )}
 
           {/*-- the main content --*/}
           <div id="main" className="main-side-editor">
             <Editor />
           </div>
+
+          {pinnedTabs.output && (
+            <IonMenu contentId="main" side="end" type="push">
+              {/* <IonHeader>
+                <IonToolbar className="side-toolbar">
+                  <IonTitle>Output</IonTitle>
+                </IonToolbar>
+              </IonHeader>
+              <IonContent forceOverscroll={true}>
+                <OutputTab />
+              </IonContent> */}
+              <OutputTab />
+            </IonMenu>
+          )}
         </IonSplitPane>
         <OpenProjectModal isOpen={showOpenModal} onDismiss={setShowOpenModal} />
         <SaveProjectModal isOpen={showSaveModal} onDismiss={setShowSaveModal} />

--- a/src/pages/OutputTab.tsx
+++ b/src/pages/OutputTab.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import {
   IonButton,
   IonButtons,
-  IonCol,
+  // IonCol,
   IonContent,
   IonHeader,
   IonIcon,
   IonPage,
-  IonRow,
+  // IonRow,
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
@@ -72,13 +72,13 @@ const OutputTab: React.FC = () => {
               onClick={clearOutput}
             >
               <IonIcon icon={backspaceOutline} />
-              <span className="margin-button-left"> Clear </span>
+              <span className="margin-button-left">Clear</span>
             </IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent scrollY={false} className="tab-content-of-hidden">
-        <IonRow style={{ height: "100%" }}>
+        {/* <IonRow style={{ height: "100%" }}>
           <IonCol
             size-md="8"
             offset-md="2"
@@ -86,10 +86,10 @@ const OutputTab: React.FC = () => {
             offset-xl="3"
             className="ion-no-padding"
             style={{ height: "100%" }}
-          >
-            <Output model={model} error={error} fontSize={fontSizeOutput} />
-          </IonCol>
-        </IonRow>
+          > */}
+        <Output model={model} error={error} fontSize={fontSizeOutput} />
+        {/* </IonCol>
+        </IonRow> */}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/RunSettingsTab.tsx
+++ b/src/pages/RunSettingsTab.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { IonCol, IonContent, IonHeader, IonPage, IonRow, IonTitle, IonToolbar } from "@ionic/react";
+import {
+  // IonCol,
+  IonContent,
+  IonHeader,
+  IonPage,
+  // IonRow,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/react";
 import RunSettings from "../components/RunSettings";
 
 const RunSettingsTab: React.FC = () => {
@@ -11,11 +19,11 @@ const RunSettingsTab: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent forceOverscroll={true}>
-        <IonRow>
-          <IonCol size-md="8" offset-md="2" size-xl="6" offset-xl="3" className="ion-no-padding">
-            <RunSettings />
-          </IonCol>
-        </IonRow>
+        {/* <IonRow>
+          <IonCol size-md="8" offset-md="2" size-xl="6" offset-xl="3" className="ion-no-padding"> */}
+        <RunSettings />
+        {/* </IonCol>
+        </IonRow> */}
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
Enable users to select which side panels to show: "Run settings" (left) and/or "Output" (right).
In case of portrait/vertical screens the side panels are shown above and below the Editor.

Still missing:

- [ ] `useSelector` for the two display settings
- [ ] Make split horizontal on portrait/vertical
- [ ] Hide `newOutput` if the panel is open?
- [ ] Hide text on the bar if there isn't enough space
- [ ] Add tooltips to buttons
- [ ] Save selected state in local storage
- [ ] Save selected font in local storage
- [ ] View/show text with 👁️ and then the same buttons as the toolbar